### PR TITLE
Generate json for Metasploit website

### DIFF
--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -100,6 +100,7 @@ last_week = today - 7
 last_month = today - 30
 
 puts 'generating json...'
+File.write('commits_modules.json', stats.commits_modules_json.to_json)
 File.write('commits_merged.json', stats.commits_merged_json.to_json)
 File.write('contributors_year.json', stats.contributers_month_json.to_json)
 File.write('contributors_all.json', stats.contributers_all_json.to_json)

--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -101,8 +101,8 @@ last_month = today - 30
 
 puts 'generating json...'
 File.write('commits_merged.json', stats.commits_merged_json.to_json)
-File.write('contributors_month.json', stats.contributers_month_json.to_json)
-File.write('contributers_all.json', stats.contributers_all_json.to_json)
+File.write('contributors_year.json', stats.contributers_month_json.to_json)
+File.write('contributors_all.json', stats.contributers_all_json.to_json)
 File.write('issues_newbie.json', stats.issues_newbie_json.to_json)
 
 puts "Making some (sausage) links..."

--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -100,6 +100,7 @@ last_week = today - 7
 last_month = today - 30
 
 puts 'generating json...'
+File.write('commits_merged.json', stats.commits_merged_json.to_json)
 File.write('contributors_month.json', stats.contributers_month_json.to_json)
 File.write('contributers_all.json', stats.contributers_all_json.to_json)
 File.write('issues_newbie.json', stats.issues_newbie_json.to_json)

--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -100,6 +100,7 @@ last_week = today - 7
 last_month = today - 30
 
 puts 'generating json...'
+File.write('contributors_month.json', stats.contributers_month_json.to_json)
 File.write('contributers_all.json', stats.contributers_all_json.to_json)
 File.write('issues_newbie.json', stats.issues_newbie_json.to_json)
 

--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -99,6 +99,9 @@ today = DateTime.now
 last_week = today - 7
 last_month = today - 30
 
+puts 'generating json...'
+File.write('contributers_all.json', stats.top_committers_json(nil, 20).to_json)
+
 puts "Making some (sausage) links..."
 toc = ''
 accordion = '

--- a/stats/generate_pages
+++ b/stats/generate_pages
@@ -100,7 +100,8 @@ last_week = today - 7
 last_month = today - 30
 
 puts 'generating json...'
-File.write('contributers_all.json', stats.top_committers_json(nil, 20).to_json)
+File.write('contributers_all.json', stats.contributers_all_json.to_json)
+File.write('issues_newbie.json', stats.issues_newbie_json.to_json)
 
 puts "Making some (sausage) links..."
 toc = ''

--- a/stats/issue.rb
+++ b/stats/issue.rb
@@ -62,6 +62,10 @@ class Issue
       title: title,
       updated_at: updated_at,
       url: url,
+      user: {
+        login: reporter,
+        html_url: 'https://github.com/' + reporter
+      }
     }.to_json(*a)
   end
 

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -109,7 +109,7 @@ class IssueStats
             message: pr[:commit][:message],
             author: pr[:author].to_h,
             html_url: pr[:commit][:html_url],
-            date: pr[:commit][:date]
+            date: pr[:commit][:author][:date].strftime("%b %d, %Y")
           }
         }.first(6)
   end

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -101,7 +101,7 @@ class IssueStats
     committers.sort_by { |k, v| v }.reverse.to_h
   end
   
-  def top_committers_json(date, limit)
+  def contributers_all_json
     contributers = []
     @projects.each do |project|
       contributers.concat @client.contribs(project)
@@ -111,7 +111,7 @@ class IssueStats
     contributers.each do |contributer|
       contributer_counts[contributer[:login]] += contributer[:contributions]
     end
-    top_20_contributers = contributer_counts.sort_by { |k, v| v }.reverse.first(limit).to_h
+    top_20_contributers = contributer_counts.sort_by { |k, v| v }.reverse.first(20).to_h
     top_20_contributer_infos = []
     top_20_contributers.each do |contributer|
       login = contributer[0]
@@ -121,5 +121,9 @@ class IssueStats
       top_20_contributer_infos << user.to_h
     end
     top_20_contributer_infos
+  end
+  
+  def issues_newbie_json
+    open_issues_on(DateTime.now, ['newbie-friendly'])
   end
 end

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -102,7 +102,10 @@ class IssueStats
   end
   
   def commits_merged_json
-    closed_prs_between(DateTime.now - 30, DateTime.now).first(6)
+    commits_merged = closed_prs_between(DateTime.now - 30, DateTime.now).first(6).each do |pr|
+      pr.labels = pr.labels.map{|l|{name: l}}
+    end
+    commits_merged
   end
   
   def contributers_month_json
@@ -145,6 +148,9 @@ class IssueStats
   end
   
   def issues_newbie_json
-    open_issues_on(DateTime.now, ['newbie-friendly']).first(10)
+    newb_issues = open_issues_on(DateTime.now, ['newbie-friendly']).first(10).each do |issue|
+      issue.labels = issue.labels.map{|l|{name: l}}
+    end
+    newb_issues
   end
 end

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -101,6 +101,19 @@ class IssueStats
     committers.sort_by { |k, v| v }.reverse.to_h
   end
   
+  def commits_modules_json
+    @client.commits_since('rapid7/metasploit-framework', DateTime.now - 30, {path: 'modules'}).
+      select{|pr|pr[:commit][:message].include?('Land #')}.
+        map{|pr|
+          {
+            message: pr[:commit][:message],
+            author: pr[:author].to_h,
+            html_url: pr[:commit][:html_url],
+            date: pr[:commit][:date]
+          }
+        }.first(6)
+  end
+  
   def commits_merged_json
     commits_merged = closed_prs_between(DateTime.now - 30, DateTime.now).first(6).each do |pr|
       pr.labels = pr.labels.map{|l|{name: l}}

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -101,6 +101,19 @@ class IssueStats
     committers.sort_by { |k, v| v }.reverse.to_h
   end
   
+  def contributers_month_json
+    commits = []
+    @projects.each do |project|
+      commits.concat @client.commits_since(project, DateTime.now - 30)
+    end
+    committers = {}
+    committers.default = 0
+    commits.each do |commit|
+      committers[commit.author.login] += 1 if !commit.author.nil?
+    end
+    top_20_contributer_infos(committers)
+  end
+  
   def contributers_all_json
     contributers = []
     @projects.each do |project|
@@ -111,6 +124,10 @@ class IssueStats
     contributers.each do |contributer|
       contributer_counts[contributer[:login]] += contributer[:contributions]
     end
+    top_20_contributer_infos(contributer_counts)
+  end
+  
+  def top_20_contributer_infos(contributer_counts)
     top_20_contributers = contributer_counts.sort_by { |k, v| v }.reverse.first(20).to_h
     top_20_contributer_infos = []
     top_20_contributers.each do |contributer|
@@ -124,6 +141,6 @@ class IssueStats
   end
   
   def issues_newbie_json
-    open_issues_on(DateTime.now, ['newbie-friendly'])
+    open_issues_on(DateTime.now, ['newbie-friendly']).first(10)
   end
 end

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -100,4 +100,26 @@ class IssueStats
     end
     committers.sort_by { |k, v| v }.reverse.to_h
   end
+  
+  def top_committers_json(date, limit)
+    contributers = []
+    @projects.each do |project|
+      contributers.concat @client.contribs(project)
+    end
+    contributer_counts = {}
+    contributer_counts.default = 0
+    contributers.each do |contributer|
+      contributer_counts[contributer[:login]] += contributer[:contributions]
+    end
+    top_20_contributers = contributer_counts.sort_by { |k, v| v }.reverse.first(limit).to_h
+    top_20_contributer_infos = []
+    top_20_contributers.each do |contributer|
+      login = contributer[0]
+      contributions = contributer[1]
+      user = @client.user(login)
+      user[:contributions] = contributions
+      top_20_contributer_infos << user.to_h
+    end
+    top_20_contributer_infos
+  end
 end

--- a/stats/stats.rb
+++ b/stats/stats.rb
@@ -101,6 +101,10 @@ class IssueStats
     committers.sort_by { |k, v| v }.reverse.to_h
   end
   
+  def commits_merged_json
+    closed_prs_between(DateTime.now - 30, DateTime.now).first(6)
+  end
+  
   def contributers_month_json
     commits = []
     @projects.each do |project|


### PR DESCRIPTION
This adds json stats file generation to the generate_pages script

## Validation
- [ ] run the `generate_pages` script
- [ ] verify the 5 generated .json files needed for the metasploit-website are generated
- [ ] copy files to local metasploit-website data dir to test all the data is wired up properly
