### PR TITLE
Add downloading latest acceptance test results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gem 'webrick'
 gem 'octokit'
+gem 'faraday-retry'
 gem 'pry-byebug'
+gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,57 +1,44 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.1.1)
     byebug (11.1.3)
     coderay (1.1.3)
-    faraday (1.10.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-net_http (3.0.2)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     method_source (1.0.0)
-    multipart-post (2.1.1)
-    octokit (4.22.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
+    octokit (7.1.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (4.0.7)
+    public_suffix (5.0.3)
     ruby2_keywords (0.0.5)
-    sawyer (0.8.2)
+    rubyzip (2.3.2)
+    sawyer (0.9.2)
       addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
+      faraday (>= 0.17.3, < 3)
     webrick (1.8.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  faraday-retry
   octokit
   pry-byebug
+  rubyzip
   webrick
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Build the stats, further details can be found in the [README.md](./stats/README.
 ```
 export GITHUB_OAUTH_TOKEN=your_token_here
 bundle exec ruby stats/generate_pages
+bundle exec ruby stats/download_acceptance_test_results.rb
 ```
 
 If you want to see the stats locally, run:

--- a/stats/download_acceptance_test_results.rb
+++ b/stats/download_acceptance_test_results.rb
@@ -1,0 +1,65 @@
+require 'octokit'
+require 'zip'
+
+if !ENV.has_key?('GITHUB_OAUTH_TOKEN')
+  puts "An authentication method environment variable must be set"
+  puts "Please set GITHUB_OAUTH_TOKEN"
+  exit 1
+end
+
+token = ENV['GITHUB_OAUTH_TOKEN']
+
+# Attempts to download the latest successful run of the Metasploit acceptance tests
+class AcceptanceTestReport
+  def initialize(access_token:, repository_name: 'rapid7/metasploit-framework')
+    @access_token = access_token
+    @repository_name = repository_name
+  end
+
+  def download
+    client = Octokit::Client.new(access_token: @access_token)
+    # Don't auto_paginate, as there might be hundreds of workflow runs - and we only want the first page
+    client.auto_paginate = false
+
+    all_workflow_runs = client.repository_workflow_runs(@repository_name, { branch: 'master' }).workflow_runs
+    latest_successful_acceptance_test = all_workflow_runs.find { |workflow_run| workflow_run.name == 'Acceptance' && workflow_run.conclusion == 'success' }
+
+    latest_artifacts = client.workflow_run_artifacts(@repository_name, latest_successful_acceptance_test.id).artifacts
+    final_report_artifact = latest_artifacts.find { |artifact| artifact.name.start_with?('final-report') }
+
+    final_report_zip_bin = client.get(final_report_artifact.archive_download_url)
+
+    final_report_io = StringIO.new
+    final_report_io.puts final_report_zip_bin
+    final_report_io.rewind
+    extract_zip(final_report_io, target_directory)
+  end
+
+  private
+
+  def current_directory
+    File.dirname(__FILE__)
+  end
+
+  def target_directory
+    File.join(current_directory, 'build', 'acceptance-tests')
+  end
+
+  def extract_zip(zip_io, target_path)
+    FileUtils.remove_entry(target_path, true)
+    FileUtils.mkdir_p(target_path)
+
+    Zip::File.open_buffer(zip_io) do |zip_file|
+      zip_file.each do |f|
+        fpath = File.join(target_path, f.name)
+        zip_file.extract(f, fpath)
+      end
+    end
+  end
+end
+
+acceptance_test_report = AcceptanceTestReport.new(
+  access_token: ENV['GITHUB_OAUTH_TOKEN'],
+)
+
+acceptance_test_report.download


### PR DESCRIPTION
Generate a github token - I used a fine grained token without any permissions (readonly)

https://github.com/settings/tokens

Download the latest test acceptance results

```
bundle install

GITHUB_OAUTH_TOKEN=token_here bundle exec ruby ./stats/download_acceptance_test_results.rb
```

Verify the download worked:

```
python3 -m http.server .
```

Visit http://localhost:8000/stats/build/acceptance-tests/ and see the report:

![image](https://github.com/rapid7/metakitty/assets/60357436/b1d3298e-5cc2-40d0-bd3b-94f59d07a7eb)

And http://localhost:8000/stats/build/acceptance-tests/support_matrix.html for the support matrix

![image](https://github.com/rapid7/metakitty/assets/60357436/e5097f6b-4877-4e3d-9e38-cf77ebd123fd)

